### PR TITLE
Add TSMC 28nm tech initialization

### DIFF
--- a/conda-env/lib/python3.9/site-packages/hammer/technology/tsmc/__init__.py
+++ b/conda-env/lib/python3.9/site-packages/hammer/technology/tsmc/__init__.py
@@ -1,251 +1,81 @@
-#  hpcplus 1p10m5X2Y2Z plugin for Hammer.
+#  TSMC 28nm plugin for Hammer.
 #
 #  See LICENSE for licence details.
 
 import sys
-import re
 import os
-import shutil
-import glob
-import subprocess
 import textwrap
-from types import new_class
-from typing import NamedTuple, List, Optional, Tuple, Dict, Set, Any
+from typing import List
 
 from hammer.tech import HammerTechnology
-from hammer.vlsi import HammerTool, HammerPlaceAndRouteTool, HammerDRCTool, MentorCalibreTool, TCLTool, HammerToolHookAction
+from hammer.vlsi import (HammerTool, HammerPlaceAndRouteTool, HammerDRCTool,
+                         MentorCalibreTool, TCLTool, HammerToolHookAction)
 
 class TSMCTech(HammerTechnology):
-    """
-    Override the HammerTechnology used in `hammer_tech.py`
-    This class is loaded by function `load_from_json`, and will pass the `try` in `importlib`.
-    Implementation for the hpcplus 1p10m5X2Y2Z technology.
-    """
+    """TSMC 28nm technology for Hammer."""
+
     def post_install_script(self) -> None:
+        """Initialize the PDK support."""
         try:
-            # Prioritize gdstk
             self.gds_tool = __import__('gdstk')
         except ImportError:
             self.logger.info("gdstk not found, falling back to gdspy...")
             try:
                 self.gds_tool = __import__('gdspy')
-                assert('1.4' in self.gds_tool.__version__)
+                assert '1.4' in self.gds_tool.__version__
             except (ImportError, AssertionError):
-                self.logger.error("Check your gdspy v1.4 installation! Unable to hack TSMC PDK.")
-                shutil.rmtree(self.cache_dir)
+                self.logger.error("Check your gdspy v1.4 installation! Unable to handle TSMC PDK.")
                 sys.exit()
-        # self.generate_multi_vt_gds()
-        # self.fix_icg_libs()
-
-    def generate_multi_vt_gds(self) -> None:
-        """
-        PDK GDS only contains RVT cells.
-        This patch will generate the other VT GDS files (LVT, ULVT, SRAM).
-        """
-        try:
-            os.makedirs(os.path.join(self.cache_dir, "GDS"))
-        except:
-            self.logger.info("Multi-VT GDS's already created")
-            return None
-
-        try:
-            self.logger.info("Generating GDS for Multi-VT cells using {}...".format(self.gds_tool.__name__))
-
-            pdk_install_dir = self.get_setting("technology.tsmc.pdk_install_dir")
-            orig_gds = os.path.join(pdk_install_dir, "Back_End/gds/tcbn28hpcplusbwp35p140hvt_110a/tcbn28hpcplusbwp35p140hvt.gds")
-
-            if self.gds_tool.__name__ == 'gdstk':
-                # load original GDS
-                hpcplus_original_gds = self.gds_tool.read_gds(infile=orig_gds)
-                original_cells = hpcplus_original_gds.cells
-                cell_list = list(map(lambda c: c.name, original_cells))
-                # required libs
-                multi_libs = {
-                    "LVT": {
-                        "lib": self.gds_tool.Library(),
-                        "mvt_layer": 98
-                        },
-                    "ULVT": {
-                        "lib": self.gds_tool.Library(),
-                        "mvt_layer": 97
-                        },
-                    "SRAM": {
-                        "lib": self.gds_tool.Library(),
-                        "mvt_layer": 110
-                        },
-                }
-                # create new libs
-                for vt, multi_lib in multi_libs.items():
-                    multi_lib['lib'].name = hpcplus_original_gds.name.replace('RVT', vt)
-
-                for cell in original_cells:
-                    # extract polygon from layer 100(the boundary for cell)
-                    boundary_polygon = next(filter(lambda p: p.layer==100, cell.polygons))
-                    for vt, multi_lib in multi_libs.items():
-                        new_cell_name = cell.name.replace('RVT', vt)
-                        cell_list.append(new_cell_name)
-                        mvt_layer = multi_lib['mvt_layer']
-                        # copy boundary_polygon to mvt_layer to mark the this cell is a mvt cell.
-                        mvt_polygon = self.gds_tool.Polygon(boundary_polygon.points, multi_lib['mvt_layer'], 0)
-                        mvt_cell = cell.copy(name=new_cell_name, deep_copy=True).add(mvt_polygon)
-                        # add mvt_cell to corresponding multi_lib
-                        multi_lib['lib'].add(mvt_cell)
-
-                for vt, multi_lib in multi_libs.items():
-                    # write multi_lib
-                    new_gds = os.path.basename(orig_gds).replace('RVT', vt)
-                    multi_lib['lib'].write_gds(os.path.join(self.cache_dir, 'GDS', new_gds))
-
-            elif self.gds_tool.__name__ == 'gdspy':
-                # load original GDS
-                hpcplus_original_gds = self.gds_tool.GdsLibrary().read_gds(infile=orig_gds, units='import')
-                original_cells = hpcplus_original_gds.cell_dict
-                cell_list = list(map(lambda c: c.name, original_cells.values()))
-                # required libs
-                multi_libs = {
-                    "LVT": {
-                        "lib": self.gds_tool.GdsLibrary(),
-                        "mvt_layer": 98
-                        },
-                    "ULVT": {
-                        "lib": self.gds_tool.GdsLibrary(),
-                        "mvt_layer": 97
-                        },
-                    "SRAM": {
-                        "lib": self.gds_tool.GdsLibrary(),
-                        "mvt_layer": 110
-                        },
-                }
-                # create new libs
-                for vt, multi_lib in multi_libs.items():
-                    multi_lib['lib'].name = hpcplus_original_gds.name.replace('RVT', vt)
-
-                for cell in original_cells.values():
-                    poly_dict = cell.get_polygons(by_spec=True)
-                    # extract polygon from layer 100(the boundary for cell)
-                    boundary_polygon = poly_dict[(100, 0)]
-                    for vt, multi_lib in multi_libs.items():
-                        new_cell_name = cell.name.replace('RVT', vt)
-                        cell_list.append(new_cell_name)
-                        mvt_layer = multi_lib['mvt_layer']
-                        # copy boundary_polygon to mvt_layer to mark the this cell is a mvt cell.
-                        mvt_polygon = self.gds_tool.PolygonSet(boundary_polygon, multi_lib['mvt_layer'], 0)
-                        mvt_cell = cell.copy(name=new_cell_name, exclude_from_current=True, deep_copy=True).add(mvt_polygon)
-                        # add mvt_cell to corresponding multi_lib
-                        multi_lib['lib'].add(mvt_cell)
-
-                for vt, multi_lib in multi_libs.items():
-                    # write multi_lib
-                    new_gds = os.path.basename(orig_gds).replace('RVT', vt)
-                    multi_lib['lib'].write_gds(os.path.join(self.cache_dir, 'GDS', new_gds))
-
-            # Write out cell list for scaling script
-            with open(os.path.join(self.cache_dir, 'stdcells.txt'), 'w') as f:
-                f.writelines('{}\n'.format(cell) for cell in cell_list)
-
-        except:
-            os.rmdir(os.path.join(self.cache_dir, "GDS"))
-            self.logger.error("GDS patching failed! Check your gdstk, gdspy, and/or hpcplus PDK installation.")
-            sys.exit()
-
-    def fix_icg_libs(self) -> None:
-        """
-        ICG cells are missing statetable.
-        """
-        try:
-            os.makedirs(os.path.join(self.cache_dir, "LIB/NLDM"))
-        except:
-            self.logger.info("ICG LIBs already fixed")
-            return None
-
-        try:
-            self.logger.info("Fixing ICG LIBs...")
-            statetable_text = "\\n".join([
-               '\    statetable ("CLK ENA SE", "IQ") {',
-                '      table : "L L L : - : L ,  L L H : - : H , L H L : - : H , L H H : - : H , H - - : - : N ";',
-                '    }'])
-            gclk_func = "CLK & IQ"
-            lib_dir = os.path.join(self.get_setting("technology.tsmc.stdcell_install_dir"), "LIB/NLDM")
-            old_libs = glob.glob(os.path.join(lib_dir, "*SEQ*"))
-            new_libs = list(map(lambda l: os.path.join(self.cache_dir, "LIB/NLDM", os.path.basename(l)), old_libs))
-
-            for olib, nlib in zip(old_libs, new_libs):
-                # Use gzip and sed directly rather than gzip python module
-                # Add the statetable to ICG cells
-                # Change function to state_function for pin GCLK
-                subprocess.call(["gzip -cd {olib} | sed '/ICGx*/a {stbl}' | sed '/CLK & IQ/s/function/state_function/g' | gzip > {nlib}".format(olib=olib, stbl=statetable_text, nlib=nlib)], shell=True)
-        except:
-            os.rmdir(os.path.join(self.cache_dir, "LIB/NLDM"))
-            os.rmdir(os.path.join(self.cache_dir, "LIB"))
-            self.logger.error("Failed to fix ICG LIBs. Check your hpcplus installation!")
-            sys.exit()
+        self.logger.info("Loaded TSMC 28nm PDK")
 
     def get_tech_par_hooks(self, tool_name: str) -> List[HammerToolHookAction]:
-        hooks = {"innovus": [
-            HammerTool.make_post_persistent_hook("init_design", hpcplus_innovus_settings),
-            HammerTool.make_post_insertion_hook("floorplan_design", hpcplus_update_floorplan),
-            #  scales a final GDS file (chip layout data) by a factor of 4
-            # HammerTool.make_post_insertion_hook("write_design", hpcplus_scale_final_gds)
-            ]}
+        hooks = {
+            "innovus": [
+                HammerTool.make_post_persistent_hook("init_design", tsmc_innovus_settings),
+                HammerTool.make_post_insertion_hook("floorplan_design", tsmc_update_floorplan),
+                # HammerTool.make_post_insertion_hook("write_design", tsmc_scale_final_gds),
+            ]
+        }
         return hooks.get(tool_name, [])
 
     def get_tech_drc_hooks(self, tool_name: str) -> List[HammerToolHookAction]:
-        hooks = {"calibre": [
-            HammerTool.make_replacement_hook("generate_drc_run_file", hpcplus_generate_drc_run_file)
-            ]}
+        hooks = {
+            "calibre": [
+                HammerTool.make_replacement_hook("generate_drc_run_file", tsmc_generate_drc_run_file)
+            ]
+        }
         return hooks.get(tool_name, [])
 
-def hpcplus_innovus_settings(ht: HammerTool) -> bool:
+
+def tsmc_innovus_settings(ht: HammerTool) -> bool:
     assert isinstance(ht, HammerPlaceAndRouteTool), "Innovus settings only for par"
     assert isinstance(ht, TCLTool), "innovus settings can only run on TCL tools"
-    """Settings that may need to be reapplied at every tool invocation
-    Note that the particular routing layer settings here will persist in Innovus;
-    this hook only serves as an example of what commands may need to persist."""
     ht.append('''
-# Set bottom and top routing layers (1p10m stack)
-# 配置10层金属堆叠(1p10m)工艺中的布线层，底层为M2，顶层为M10
 set_db route_design_bottom_routing_layer 2
 set_db route_design_top_routing_layer 10
-
-# Ignore 1e+31 removal arcs for ASYNC DFF cells
-
 set_db timing_analysis_async_checks no_async
-
-# Via preferences for stripes - adjusted for 10 metal layers with 5X/2Y/2Z configuration
-# 特殊过孔(via)规则设置
 set_db generate_special_via_rule_preference { M10_M9widePWR1p4 M9_M8widePWR1p4 M8_M7widePWR1p2 M7_M6widePWR1p2 M6_M5widePWR1p0 M5_M4widePWR1p0 M4_M3widePWR0p9 M3_M2widePWR0p9 }
-
-# Prevent extending M1 pins in cells
 set_db route_design_with_via_in_pin true
-    ''')
+''')
     return True
 
-def hpcplus_update_floorplan(ht: HammerTool) -> bool:
-    assert isinstance(ht, HammerPlaceAndRouteTool), "hpcplus_update_floorplan can only run on par"
-    assert isinstance(ht, TCLTool), "hpcplus_update_floorplan can only run on TCL tools"
-    """
-    This is needed to block top/bottom site rows and re-do wiring tracks.
-    This resolves many DRCs and removes the need for the user to do it in placement constraints.
-    Adapted for hpcplus technology with specific track offsets.
-    """
+
+def tsmc_update_floorplan(ht: HammerTool) -> bool:
+    assert isinstance(ht, HammerPlaceAndRouteTool), "tsmc_update_floorplan can only run on par"
+    assert isinstance(ht, TCLTool), "tsmc_update_floorplan can only run on TCL tools"
     ht.append('''
-# Need to delete and recreate tracks based on tech LEF pitches but overriding offsets
-# Adjusting offsets for different metal layers in 1p10m5X2Y2Z configuration
-# 布线轨道设置
-add_tracks -honor_pitch -offsets { 
-    M1 vert 0.050 
-    M2 horiz 0.050 
-    M3 vert 0.050 
-    M4 horiz 0.050 
-    M5 vert 0.050 
-    M6 horiz 0.070 
-    M7 vert 0.070 
-    M8 horiz 0.090 
-    M9 vert 0.090 
-    M10 horiz 0.090 
+add_tracks -honor_pitch -offsets {
+    M1 vert 0.050
+    M2 horiz 0.050
+    M3 vert 0.050
+    M4 horiz 0.050
+    M5 vert 0.050
+    M6 horiz 0.070
+    M7 vert 0.070
+    M8 horiz 0.090
+    M9 vert 0.090
+    M10 horiz 0.090
 }
-# 布局阻塞区创建
-# Create place blockage on top & bottom row, fixes wiring issue + power vias for DRC/LVS
 set core_lly [get_db current_design .core_bbox.ll.y]
 set core_ury [expr [get_db current_design .core_bbox.ur.y] - 1.10]
 set botrow [get_db rows -if {.rect.ll.y == $core_lly}]
@@ -255,32 +85,22 @@ create_place_blockage -area [get_db $toprow .rect] -name ROW_BLOCK_TOP
 ''')
     return True
 
-def hpcplus_scale_final_gds(ht: HammerTool) -> bool:
-    assert isinstance(ht, HammerPlaceAndRouteTool), "hpcplus_scale_final_gds can only run on par"
-    assert isinstance(ht, TCLTool), "hpcplus_scale_final_gds can only run on TCL tools"
-    """
-    Scale the final GDS by a factor of 4
-    scale_gds_script writes the actual Python script to execute from the Tcl interpreter
-    """
-    # This is from the Cadence tools
-    cadence_output_gds_name = ht.output_gds_filename  # type: ignore
 
+def tsmc_scale_final_gds(ht: HammerTool) -> bool:
+    assert isinstance(ht, HammerPlaceAndRouteTool), "tsmc_scale_final_gds can only run on par"
+    assert isinstance(ht, TCLTool), "tsmc_scale_final_gds can only run on TCL tools"
+    cadence_output_gds_name = ht.output_gds_filename  # type: ignore
     ht.append('''
-# Innovus <19.1 appends some bad LD_LIBRARY_PATHS, so remove them before executing python
 set env(LD_LIBRARY_PATH) [join [lsearch -not -all -inline [split $env(LD_LIBRARY_PATH) ":"] "*INNOVUS*"] ":"]
-hpcplus_gds_scale {stdcells_file} {gds_file}
-'''.format(stdcells_file = os.path.join(ht.technology.cache_dir, 'stdcells.txt'),
-           gds_file = cadence_output_gds_name))
+tsmc_gds_scale {stdcells_file} {gds_file}
+'''.format(stdcells_file=os.path.join(ht.technology.cache_dir, 'stdcells.txt'),
+           gds_file=cadence_output_gds_name))
     return True
 
-def hpcplus_generate_drc_run_file(ht: HammerTool) -> bool:
-    assert isinstance(ht, HammerDRCTool), "hpcplus_generate_drc_run_file can only run on drc"
-    assert isinstance(ht, MentorCalibreTool), "hpcplus_generate_drc_run_file can only run on a Calibre tool"
-    """
-    Replace drc_run_file to prevent conflicting SVRF statements
-    Symlink DRC GDS to test.gds as expected by deck and results directories
-    """
-    # These are from the Calibre tools
+
+def tsmc_generate_drc_run_file(ht: HammerTool) -> bool:
+    assert isinstance(ht, HammerDRCTool), "tsmc_generate_drc_run_file can only run on drc"
+    assert isinstance(ht, MentorCalibreTool), "tsmc_generate_drc_run_file can only run on a Calibre tool"
     ht_drc_run_file = ht.drc_run_file  # type: ignore
     ht_max_drc_results = ht.max_drc_results  # type: ignore
     ht_virtual_connect_colon = ht.virtual_connect_colon  # type: ignore
@@ -292,7 +112,7 @@ def hpcplus_generate_drc_run_file(ht: HammerTool) -> bool:
 
     with open(ht_drc_run_file, "w") as f:
         f.write(textwrap.dedent("""
-        // Generated by HAMMER for hpcplus 1p10m5X2Y2Z
+        // Generated by HAMMER for TSMC 28nm
 
         DRC MAXIMUM RESULTS {max_results}
         DRC MAXIMUM VERTEX 4096
@@ -303,14 +123,10 @@ def hpcplus_generate_drc_run_file(ht: HammerTool) -> bool:
         VIRTUAL CONNECT REPORT NO
         """).format(
             max_results=ht_max_drc_results,
-            virtual_connect="YES" if ht_virtual_connect_colon else "NO"
-        )
-        )
-        # Include paths to all supplied decks
+            virtual_connect="YES" if ht_virtual_connect_colon else "NO",
+        ))
         for rule in ht.get_drc_decks():
             f.write("INCLUDE \"{}\"\n".format(rule.path))
-        # Note that an empty list means run all, and Calibre conveniently will do just that
-        # if we don't specify any individual checks to run.
         if len(ht.drc_rules_to_run()) > 0:
             f.write("\nDRC SELECT CHECK\n")
         for check in ht.drc_rules_to_run():
@@ -318,5 +134,6 @@ def hpcplus_generate_drc_run_file(ht: HammerTool) -> bool:
         f.write("\nDRC ICSTATION YES\n")
         f.write(ht.get_additional_drc_text())
     return True
+
 
 tech = TSMCTech()


### PR DESCRIPTION
## Summary
- rewrite `hammer.technology.tsmc` initialization for TSMC 28nm
- add Innovus and Calibre hook helpers
- remove unused multi-VT and ICG fix logic

## Testing
- `tox -e format` *(fails: no config)*

------
https://chatgpt.com/codex/tasks/task_e_685a3f498e388327b9018ec42f705516