### PR TITLE
Add TSMC technology plugin

### DIFF
--- a/conda-env/lib/python3.9/site-packages/hammer/technology/tsmc/__init__.py
+++ b/conda-env/lib/python3.9/site-packages/hammer/technology/tsmc/__init__.py
@@ -1,0 +1,46 @@
+# TSMC 28nm technology plugin for Hammer.
+#
+# See LICENSE for license details.
+
+import os
+from typing import List
+
+from hammer.tech import HammerTechnology
+from hammer.vlsi import HammerTool, HammerPlaceAndRouteTool, HammerDRCTool, TCLTool, HammerToolHookAction
+
+class TSMC28Tech(HammerTechnology):
+    """Hammer technology class for the TSMC 28nm PDK."""
+
+    def post_install_script(self) -> None:
+        """Perform any initialization needed after installing the PDK."""
+        self.logger.info("Loaded TSMC28 Technology")
+
+    def get_tech_par_hooks(self, tool_name: str) -> List[HammerToolHookAction]:
+        hooks = {"innovus": [
+            HammerTool.make_post_persistent_hook("init_design", tsmc_innovus_settings)
+        ]}
+        return hooks.get(tool_name, [])
+
+    def get_tech_drc_hooks(self, tool_name: str) -> List[HammerToolHookAction]:
+        hooks = {"calibre": [
+            HammerTool.make_post_persistent_hook("init_design", tsmc_calibre_settings)
+        ]}
+        return hooks.get(tool_name, [])
+
+
+def tsmc_innovus_settings(ht: HammerTool) -> bool:
+    assert isinstance(ht, HammerPlaceAndRouteTool), "Innovus settings only for par"
+    assert isinstance(ht, TCLTool), "innovus settings can only run on TCL tools"
+    ht.append('set_db route_design_bottom_routing_layer 1')
+    ht.append('set_db route_design_top_routing_layer 10')
+    return True
+
+
+def tsmc_calibre_settings(ht: HammerTool) -> bool:
+    assert isinstance(ht, HammerDRCTool), "Calibre settings only for DRC"
+    assert isinstance(ht, TCLTool), "Calibre settings can only run on TCL tools"
+    # Placeholder for any Calibre specific settings needed for the TSMC PDK
+    return True
+
+
+tech = TSMC28Tech()


### PR DESCRIPTION
## Summary
- add `tsmc/__init__.py` under conda site‑packages to register TSMC28 technology
- define par and drc hooks and Innovus settings

## Testing
- `python -m py_compile rv-opt-tsmc/old_VLSI_observation5_tsmc_boom.py conda-env/lib/python3.9/site-packages/hammer/technology/tsmc/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_685916ee83a48327a2adf551f0fc8b40